### PR TITLE
Aggressively reduce mobile navigation spacing (v2)

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -479,9 +479,13 @@ p {
 }
 
 @media (max-width: 768px) {
+    .navbar {
+        padding: var(--space-2) 0;
+    }
+
     .nav-menu {
         flex-direction: column;
-        gap: var(--space-2);
+        gap: 0;
         align-items: stretch; /* Full width on mobile */
         min-height: auto;
     }
@@ -491,16 +495,25 @@ p {
         justify-content: center;
     }
 
+    .nav-link {
+        padding: var(--space-2);
+        font-size: 0.9rem;
+    }
+
     .nav-container {
         flex-direction: column;
-        gap: var(--space-4);
+        gap: var(--space-2);
         min-height: auto;
-        padding: var(--space-4) var(--space-6);
+        padding: var(--space-2) var(--space-4);
+    }
+
+    .nav-search {
+        margin: 0;
     }
 
     .nav-user-menu {
         flex-direction: column;
-        gap: var(--space-2);
+        gap: 0;
         width: 100%;
         align-items: center;
     }
@@ -513,6 +526,8 @@ p {
     .nav-user-trigger {
         justify-content: center;
         width: 100%;
+        padding: var(--space-2);
+        font-size: 0.9rem;
     }
 
     .nav-user-dropdown-menu {
@@ -1089,18 +1104,6 @@ footer {
 }
 
 @media (max-width: 768px) {
-    .nav-container {
-        flex-direction: column;
-        gap: var(--space-4);
-        padding: var(--space-4);
-    }
-
-    .nav-menu {
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: var(--space-4);
-    }
-
     .hero-title {
         font-size: 2.5rem;
     }
@@ -1144,12 +1147,35 @@ footer {
 
 @media (max-width: 480px) {
     .container {
-        padding: 0 var(--space-4);
+        padding: 0 var(--space-3);
+    }
+
+    .navbar {
+        padding: var(--space-1) 0;
+    }
+
+    .nav-container {
+        padding: var(--space-1) var(--space-3);
+        gap: var(--space-1);
+    }
+
+    .nav-logo {
+        font-size: 1.5rem;
+    }
+
+    .nav-link {
+        padding: var(--space-1) var(--space-2);
+        font-size: 0.85rem;
+    }
+
+    .nav-user-trigger {
+        padding: var(--space-1) var(--space-2);
+        font-size: 0.85rem;
     }
 
     .hero-section,
     .page-header {
-        padding: var(--space-4) 0;
+        padding: var(--space-3) 0;
     }
 
     .hero-title {
@@ -1157,15 +1183,15 @@ footer {
     }
 
     .features-section {
-        padding: var(--space-8) 0;
+        padding: var(--space-6) 0;
     }
 
     .content-section {
-        padding: var(--space-4) 0;
+        padding: var(--space-3) 0;
     }
 
     .contact-form {
-        padding: var(--space-4);
+        padding: var(--space-3);
     }
 }
 


### PR DESCRIPTION
## Problem
After the first attempt, mobile users are still seeing excessive white space on the home page. The navigation menu items stack vertically on mobile and take up too much screen real estate, pushing the main content far down the page.

## Root Cause
The mobile navigation was using too much vertical space due to:
1. Large gaps between nav-container elements (16px)
2. Large padding on navbar and nav-container
3. Gaps between individual nav menu items
4. Standard-sized text and padding that didn't scale down enough for mobile
5. Duplicate CSS rules that were overriding compact styles

## Solution
Applied aggressive spacing reductions:
- **Navbar padding**: 1rem → 0.5rem (tablet) → 0.25rem (mobile)
- **Nav-container gap**: 1rem → 0.5rem (tablet) → 0.25rem (mobile)
- **Nav-container padding**: Reduced to 0.5rem on tablet, 0.25rem on mobile
- **Nav-menu gap**: Set to 0 to eliminate spacing between items
- **Nav-link & user trigger**: Reduced padding and font-size (0.9rem tablet, 0.85rem mobile)
- **Nav-logo**: Made smaller on mobile (1.5rem)
- **Removed duplicate** @media queries
- **Page content**: Reduced padding on page-header and content-section

## Testing
Please test on mobile device (especially the device shown in screenshot) and verify:
- Navigation is compact and doesn't take up excessive vertical space
- All links are still easily tappable
- Content appears near the top of the screen after nav
- No visual issues with compressed spacing