### PR TITLE
Add cache-busting parameter to CSS file

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1319,7 +1319,7 @@ $performanceData = [
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/assets/css/style.css?v=<?php echo time(); ?>">
 </head>
 <body>
     <header>


### PR DESCRIPTION
## Problem
After deploying updates to production, CSS changes were not visible because browsers were serving cached versions of style.css. The Actions column in the admin user table and other recent CSS changes weren't appearing even though the files were identical on dev and production.

## Root Cause
The CSS file was loaded without a cache-busting version parameter:
```html
<link rel="stylesheet" href="/assets/css/style.css">
```

While the JS file had one:
```html
<script src="/assets/js/app.js?v=1735365542"></script>
```

## Solution
Added a dynamic cache-busting parameter to the CSS file using PHP's `time()` function:
```html
<link rel="stylesheet" href="/assets/css/style.css?v=<?php echo time(); ?>">
```

This ensures that every page load checks for the latest CSS file, and any deployment with CSS changes will automatically bust the cache.

## Result
- ✅ CSS changes will be immediately visible after deployment
- ✅ No more need for hard refresh (Ctrl+F5) after updates
- ✅ Consistent with existing JS cache-busting approach
- ✅ Fixes current issue with Actions column not appearing in production

## Note
After merging and deploying, users may need **one final hard refresh** (Ctrl+F5 / Cmd+Shift+R) to pick up this change. After that, all future CSS updates will load automatically.