### PR TITLE
Remove Zipcode column from admin user table to fix Actions visibility

### DIFF
--- a/templates/admin.php
+++ b/templates/admin.php
@@ -141,7 +141,6 @@ $flashMessage = showFlashMessage();
                             <th>Name</th>
                             <th>Email</th>
                             <th>Display Name</th>
-                            <th>Zipcode</th>
                             <th>Admin</th>
                             <th>Verified</th>
                             <th>Last Login</th>
@@ -153,7 +152,7 @@ $flashMessage = showFlashMessage();
                     <tbody>
                         <?php if (empty($allUsers)): ?>
                             <tr>
-                                <td colspan="10" class="no-data">No users found</td>
+                                <td colspan="9" class="no-data">No users found</td>
                             </tr>
                         <?php else: ?>
                             <?php foreach ($allUsers as $user): ?>
@@ -163,23 +162,22 @@ $flashMessage = showFlashMessage();
                                             <img src="<?php echo escape($user['picture']); ?>" alt="" class="user-avatar">
                                         <?php endif; ?>
                                         <span><?php echo escape($user['name']); ?></span>
-                                    </td>
-                                    <td><?php echo escape($user['email']); ?></td>
-                                    <td><?php echo escape($user['display_name'] ?? '-'); ?></td>
-                                    <td><?php echo escape($user['zipcode'] ?? '-'); ?></td>
-                                    <td>
-                                        <?php 
-                                        // Check if user is super admin (defined in config)
-                                        $isSuperAdmin = defined('ADMIN_USER_ID') && $user['id'] === ADMIN_USER_ID;
-                                        $isAdmin = isset($user['is_admin']) && $user['is_admin'];
-                                        
-                                        if ($isSuperAdmin): ?>
-                                            <span class="badge badge-super-admin">SUPER</span>
-                                        <?php elseif ($isAdmin): ?>
-                                            <span class="badge badge-admin">Yes</span>
-                                        <?php else: ?>
-                                            <span class="badge badge-user">No</span>
-                                        <?php endif; ?>
+                    </td>
+                    <td><?php echo escape($user['email']); ?></td>
+                    <td><?php echo escape($user['display_name'] ?? '-'); ?></td>
+                    <td>
+                        <?php 
+                        // Check if user is super admin (defined in config)
+                        $isSuperAdmin = defined('ADMIN_USER_ID') && $user['id'] === ADMIN_USER_ID;
+                        $isAdmin = isset($user['is_admin']) && $user['is_admin'];
+                        
+                        if ($isSuperAdmin): ?>
+                            <span class="badge badge-super-admin">SUPER</span>
+                        <?php elseif ($isAdmin): ?>
+                            <span class="badge badge-admin">Yes</span>
+                        <?php else: ?>
+                            <span class="badge badge-user">No</span>
+                        <?php endif; ?>
                                     </td>
                                     <td>
                                         <?php if ($user['verified_email']): ?>


### PR DESCRIPTION
## Problem
The admin user management table has 10 columns, making it too wide for most screens. The Actions column (with the Edit button) was off-screen to the right and required horizontal scrolling to see it. This made it difficult for admins to quickly edit users.

## Solution
Removed the Zipcode column from the main table display. The zipcode is still:
- ✅ Stored in the database
- ✅ Visible and editable in the Edit User modal
- ✅ Just not shown in the main table listing

## Changes
- Removed `<th>Zipcode</th>` from table header
- Removed `<td>` with zipcode from table body
- Updated colspan from 10 to 9 in the "No users found" row

## Result
- Table now has 9 columns instead of 10
- Actions column is now visible without horizontal scrolling
- Table fits comfortably on standard screens
- Edit button is immediately accessible

## Testing
- Verify Actions column (Edit button) is visible in admin user table
- Verify no horizontal scrollbar appears
- Verify Edit User modal still shows and can edit zipcode
- Test on various screen sizes