### PR TITLE
Fix item deletion to remove database entries

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -401,6 +401,11 @@ if ($ajaxAction && in_array($ajaxAction, ['add_claim', 'remove_claim', 'remove_c
                     }
                 }
 
+                // Delete the item from the database
+                if (!deleteItemFromDb($trackingNumber)) {
+                    throw new Exception('Failed to delete item from database');
+                }
+
                 // Clear caches since we deleted an item
                 clearItemsCache();
                 clearImageUrlCache();


### PR DESCRIPTION
## Problem
Deleting an item was only removing S3 files (YAML and images) but leaving the database record intact, causing deleted items to still appear in listings.

## Solution
Added proper database deletion functionality.

## Changes
- **New function**: `deleteItemFromDb()` in `includes/items.php`
  - Deletes from `items_communities` table (foreign key associations)
  - Deletes from `claims` table (any claims on the item)
  - Deletes from `items` table (main item record)
  - Uses transactions to ensure atomic deletion
- **Updated**: `delete_item` handler in `public/index.php` to call `deleteItemFromDb()`

## Testing
✅ Tested on localhost - items are now fully deleted from both S3 and database
✅ Database entries are properly removed
✅ Associated claims and community links are cleaned up

## Impact
Items will now be completely removed when deleted, fixing the issue where deleted items remained visible in the database.