### PR TITLE
Add user link to Slack notifications

### DIFF
--- a/includes/slack.php
+++ b/includes/slack.php
@@ -17,21 +17,23 @@ function sendSlackItemNotification($webhookUrl, $item, $community) {
         return false;
     }
 
-    // Build the item URL
+    // Build the item URL and user listings URL
     $baseUrl = getBaseUrl();
     $itemUrl = $baseUrl . '/?page=item&id=' . urlencode($item['id']);
+    $userUrl = $baseUrl . '/?page=user-listings&id=' . urlencode($item['user_id']);
+    $userName = $item['user_name'] ?? 'Unknown User';
 
     error_log("Preparing Slack notification for item {$item['id']}, URL: $itemUrl");
 
     // Create a simple message with the URL - Slack will unfurl it automatically
     $message = [
-        'text' => "📦 New item posted in {$community['short_name']}: {$item['title']}",
+        'text' => "📦 New item posted in {$community['short_name']} by {$userName}: {$item['title']}",
         'blocks' => [
             [
                 'type' => 'section',
                 'text' => [
                     'type' => 'mrkdwn',
-                    'text' => "*New item posted in {$community['short_name']}*\n\n<{$itemUrl}|{$item['title']}>"
+                    'text' => "*New item posted in {$community['short_name']} by <{$userUrl}|{$userName}>*\n\n<{$itemUrl}|{$item['title']}>"
                 ]
             ]
         ],


### PR DESCRIPTION
## Enhancement
Added a clickable link to the poster's user-listings page in Slack notifications.

## Changes
Modified `includes/slack.php` to enhance the notification message:

**Before:**
```
New item posted in mosaic
```

**After:**
```
New item posted in mosaic by Bob Smith
```
Where "Bob Smith" is a clickable link to their user-listings page (`/?page=user-listings&id=USER_ID`)

## Implementation
- Built user listings URL using `user_id` from item data
- Updated both the text fallback and formatted Slack message
- Uses Slack's markdown format for the clickable link: `<url|text>`

## Benefits
- Community members can quickly see all items from a specific poster
- Provides transparency about who's posting items
- Improves community engagement

## Testing
✅ Notification format updated  
✅ User link properly formatted for Slack  
✅ Fallback text includes user name