### PR TITLE
Add visual indicator for gone items

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1709,6 +1709,31 @@ footer {
     object-fit: contain;
 }
 
+/* GONE Badge */
+.gone-badge {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: rgba(220, 38, 38, 0.95);
+    color: white;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-weight: 700;
+    font-size: 1rem;
+    letter-spacing: 0.5px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    z-index: 10;
+}
+
+/* Dim gone items slightly */
+.item-gone {
+    opacity: 0.75;
+}
+
+.item-gone:hover {
+    opacity: 0.85;
+}
+
 /* Loading indicator styles */
 .loading-indicator {
     display: flex;

--- a/templates/item-card.php
+++ b/templates/item-card.php
@@ -36,7 +36,7 @@ $isItemGone = $item['is_item_gone'] ?? false;
 $imageUrl = $item['image_url'] ?? null;
 ?>
 
-<div class="item-card">
+<div class="item-card <?php echo $isItemGone ? 'item-gone' : ''; ?>">
     <a href="?page=item&id=<?php echo escape($item['id']); ?>" class="item-link">
         <div class="item-image-container">
             <?php if ($imageUrl) : ?>
@@ -52,6 +52,10 @@ $imageUrl = $item['image_url'] ?? null;
                     <span>🖼️</span>
                     <p>No Image</p>
                 </div>
+            <?php endif; ?>
+            
+            <?php if ($isItemGone) : ?>
+                <div class="gone-badge">GONE</div>
             <?php endif; ?>
         </div>
 

--- a/templates/item.php
+++ b/templates/item.php
@@ -186,6 +186,10 @@ $flashMessage = showFlashMessage();
                                 ↻
                             </button>
                         <?php endif; ?>
+                        
+                        <?php if ($isItemGone) : ?>
+                            <div class="gone-badge">GONE</div>
+                        <?php endif; ?>
                     </div>
                     
                     <?php if (count($allImages) > 1) : ?>


### PR DESCRIPTION
## Changes
- Added red GONE badge overlay on item images for items marked as gone
- Items marked as gone are now dimmed to 75% opacity (85% on hover) for better visual distinction
- Badge displays on both item cards and item detail pages

## Visual Changes
- Red badge with white text positioned at top-right of item images
- Subtle opacity reduction helps users quickly identify gone items in listings

## Testing
- Tested with items where `is_item_gone = 1` in the database
- Badge appears correctly on both listing cards and detail pages