### PR TITLE
Show claim status to all users and improve button clarity

### DIFF
--- a/templates/item-card.php
+++ b/templates/item-card.php
@@ -145,7 +145,7 @@ $imageUrl = $item['image_url'] ?? null;
                 <?php else : ?>
                     <button onclick="markItemGone('<?php echo escape($item['id']); ?>')"
                             class="btn btn-warning">
-                        ✅ Gone!
+                        ✅ Mark as Gone
                     </button>
                 <?php endif; ?>
 
@@ -186,7 +186,7 @@ $imageUrl = $item['image_url'] ?? null;
                 <?php else : ?>
                     <button onclick="markItemGone('<?php echo escape($item['id']); ?>')"
                             class="btn btn-warning">
-                        ✅ Gone!
+                        ✅ Mark as Gone
                     </button>
                 <?php endif; ?>
 

--- a/templates/item.php
+++ b/templates/item.php
@@ -332,7 +332,21 @@ $flashMessage = showFlashMessage();
                         // Get active claims for this item
                         $activeClaims = getActiveClaims($item['id']);
                         $primaryClaim = getPrimaryClaim($item['id']);
+                        $claimCount = count($activeClaims);
                         ?>
+                        
+                        <div class="detail-item">
+                            <strong>Interest:</strong>
+                            <span>
+                                <?php if ($claimCount === 0) : ?>
+                                    <span style="color: #28a745;">No one has claimed this yet</span>
+                                <?php elseif ($claimCount === 1) : ?>
+                                    <span style="color: #ffc107;">1 person has claimed this</span>
+                                <?php else : ?>
+                                    <span style="color: #dc3545;"><?php echo $claimCount; ?> people have claimed this</span>
+                                <?php endif; ?>
+                            </span>
+                        </div>
                         
                         <?php if ($primaryClaim) : ?>
                             <div class="detail-item">
@@ -348,13 +362,6 @@ $flashMessage = showFlashMessage();
                                     ?>
                                 </span>
                                 <span class="claim-date">(<?php echo escape(date('M j, Y', strtotime($primaryClaim['claimed_at']))); ?>)</span>
-                            </div>
-                        <?php endif; ?>
-                        
-                        <?php if (count($activeClaims) > 1) : ?>
-                            <div class="detail-item">
-                                <strong>Waitlist:</strong>
-                                <span><?php echo count($activeClaims) - 1; ?> person<?php echo (count($activeClaims) - 1) !== 1 ? 's' : ''; ?> waiting</span>
                             </div>
                         <?php endif; ?>
                     </div>
@@ -419,7 +426,7 @@ $flashMessage = showFlashMessage();
                                 <button onclick="markItemGone('<?php echo escape($item['id']); ?>')" 
                                         class="btn btn-warning btn-large" 
                                         title="Mark this item as gone">
-                                    ✅ Gone!
+                                    ✅ Mark as Gone
                                 </button>
                             <?php endif; ?>
                             


### PR DESCRIPTION
## Changes
- Added 'Interest' indicator in item detail page that shows claim count to everyone (including logged out users)
- Color-coded claim status:
  - **Green**: No claims yet
  - **Yellow**: 1 person has claimed
  - **Red**: Multiple people have claimed
- Changed button text from 'Gone!' to 'Mark as Gone' for better clarity
- Applied button text change to both item detail page and user listings page

## Why These Changes?
1. **Better transparency**: Logged out users can now see if there's already interest in an item before deciding to log in and claim it
2. **Clearer UI**: The 'Mark as Gone' button text makes it more obvious what the action does (vs the ambiguous 'Gone!')

## Testing
- Verify claim count displays correctly for items with 0, 1, and multiple claims
- Verify button text shows 'Mark as Gone' on both item detail and user listings pages
- Verify logged out users can see the claim information