### PR TITLE
Add 'Claim this item' button for non-logged-in users on item page (fixes #33)

### DIFF
--- a/templates/item.php
+++ b/templates/item.php
@@ -404,6 +404,10 @@ $flashMessage = showFlashMessage();
                                     ❌ Cannot claim
                                 </button>
                             <?php endif; ?>
+                        <?php elseif (!$isOwnItem && !$currentUser && !$isItemGone) : ?>
+                            <a href="/?page=auth&action=google" class="btn btn-primary btn-large claim-btn" title="Sign in with Google to claim this item">
+                                🏆 Claim this item
+                            </a>
                         <?php endif; ?>
                         
                         <?php if ($canEditItem) : ?>


### PR DESCRIPTION
## Problem
When a direct link to an item was shared (e.g. `?page=item&id=...`), the destination page had no "Log in to claim" or "Claim this item" button for visitors who weren't logged in. Only "Contact Seller" and "Share" were shown.

## Solution
Added a **Claim this item** button that appears when:
- The user is **not** logged in
- The item is **not** their own
- The item is **not** gone

The button links directly to Google OAuth (`/?page=auth&action=google`) so users can sign in and then claim.

## Changes
- `templates/item.php`: Added `elseif` block for `!$currentUser && !$isItemGone` that renders an `<a>` styled as the primary claim button.

## Testing
- Verified in incognito: "Claim this item" appears on item pages when not logged in
- Button navigates to Google sign-in
- Button does not appear for gone items
- Logged-in flow unchanged (Claim this! / Remove me / Cannot claim)

Fixes #33

Made with [Cursor](https://cursor.com)